### PR TITLE
Update Types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -8,15 +8,18 @@ declare namespace DataTables {
 
 	interface ColResizeSettings {
 		isEnabled?: boolean;
+		saveState?: boolean;
 		hoverClass?: string;
 		hasBoundCheck?: boolean;
 		minBoundClass?: string;
 		maxBoundClass?: string;
-		isResizable?: (column : ColumnLegacy) => boolean;
-		onResizeStart?: (column: ColumnLegacy, columns : (ColumnLegacy)[]) => void;
+		isResizable?: (column: ColumnLegacy) => boolean;
+		onResizeStart?: (column: ColumnLegacy, columns: (ColumnLegacy)[]) => void;
 		onResize?: (column: ColumnLegacy) => void;
-		onResizeEnd?: (column: ColumnLegacy, columns : (ColumnLegacy)[]) => void;
-		getMinWidthOf?: ($thNode : JQuery<HTMLTableCellElement>) => number;
+		onResizeEnd?: (column: ColumnLegacy, columns: (ColumnLegacy)[]) => void;
+		getMinWidthOf?: ($thNode: JQuery<HTMLTableCellElement>) => number;
+		stateSaveCallback?: (settings: DataTables.ColResizeSettings, data: any[]) => void;
+		stateLoadCallback?: (settings: DataTables.ColResizeSettings) => void;
 	}
 
 	interface Api {


### PR DESCRIPTION
Great plugin by the way! It was really easy to use. 

In this PR, I've added settings that are in the [readme](https://github.com/dhobi/datatables.colResize#options) and [js](https://github.com/dhobi/datatables.colResize/blob/master/jquery.dataTables.colResize.js) file but missing from the [types.d.ts](https://github.com/dhobi/datatables.colResize/blob/master/types.d.ts):
* [`saveState`](https://github.com/dhobi/datatables.colResize#:~:text=on%20dataTable%20init-,savestate,-default%20false)
* [`stateSaveCallback`](https://github.com/dhobi/datatables.colResize#:~:text=Minimum%2030px%20width-,statesavecallback,-default%3A%20uses%20localStorage)
* [`stateLoadCallback`](https://github.com/dhobi/datatables.colResize#:~:text=example%3A%20%5B437%2C412%2C416%2C258%2C397%2C357%5D-,stateloadcallback,-default%3A%20uses%20localStorage)